### PR TITLE
Fix linker errors related to Abseil library in Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ all: FLAGS+=-O3 -g
 all: include/protos/api.pb.h matrix trampoline build/diagnosis
 
 matrix: $(ALL_OBJECTS)
-	g++ -std=c++20 $(FLAGS) -g -o matrix $(ALL_OBJECTS) $(LIBS) $(INCLUDES)
+	g++ -std=c++20 $(FLAGS) -g -o matrix $(ALL_OBJECTS) -labsl_log_internal_check_op -labsl_log_internal_message $(LIBS) $(INCLUDES)
 
 trampoline: src/trampoline.cpp build/x-raise
 	g++ -o trampoline src/trampoline.cpp


### PR DESCRIPTION
This pull request addresses linker errors encountered during compilation due to missing symbols from the Abseil library. The errors were caused by the linker not being instructed to include all necessary Abseil libraries.

To resolve the issue, I have updated the Makefile to include the missing Abseil libraries explicitly. Specifically, I added -labsl_log_internal_check_op and -labsl_log_internal_message to the linker flags. These changes ensure that the linker can find the required symbols (_ZN4absl12lts_2024011612log_internal17MakeCheckOpStringIPKvS4_EEPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_T0_PKc and _ZN4absl12lts_2024011612log_internal17MakeCheckOpStringIPKvS4_EEPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_T0_PKc) and successfully link the program.

This fix resolves the compilation issue and ensures that the project can be built without encountering linker errors related to Abseil dependencies.