### PR TITLE
Update installation command options for Arch Linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ I'm currently working on an issue with protobuf compilation errors for Arch. [Th
 If you are on Arch and would like to help with a PR that I can get merged into master, try out [this PR](https://github.com/collinalexbell/HackMatrix/pull/55) and let me know in the PR comments if it works for you. It would be much appreciated!
 
 ```bash
-sudo pacman -S xdotool dmenu xorg-server xorg-xinit xorg-xwininfo xorg-xrandr protobuf base-devel zeromq libx11 libxcomposite libxtst libxext libxfixes spdlog fmt glfw-x11 mesa assimp sqlite
+sudo pacman -S --needed xdotool dmenu xorg-server xorg-xinit xorg-xwininfo xorg-xrandr protobuf base-devel zeromq libx11 libxcomposite libxtst libxext libxfixes spdlog fmt glfw-x11 mesa assimp sqlite
 ```
 #### Gentoo
 ```bash


### PR DESCRIPTION
the original command can reinstall the packages that already installed, add "--needed" option can avoid it.

'pacman -Sh' shows
"--needed         do not reinstall up to date packages"