### PR TITLE
fix getLookedAtApp -ve distance bug

### DIFF
--- a/src/WindowManager/Space.cpp
+++ b/src/WindowManager/Space.cpp
@@ -118,7 +118,7 @@ optional<entt::entity> Space::getLookedAtApp() {
     float x = intersection.intersectionPoint.x;
     float y = intersection.intersectionPoint.y;
     if (x > minX && x < maxX && y > minY && y < maxY &&
-        intersection.dist < DIST_LIMIT) {
+        intersection.dist < DIST_LIMIT && intersection.dist > 0.0) {
       return entity;
     }
   }


### PR DESCRIPTION
When selecting an application window by clicking with the mouse or pressing r, the window with the smallest distance to the camera is selected. If a window is behind the camera, this results in a negative distance and so that window is (erroniously) selected.

This commit adds a check that the distance is greater than zero to fix this.