### PR TITLE
Fix error in gentoo installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ sudo pacman -S --needed xdotool rofi xorg-server xorg-xinit xorg-xwininfo xorg-x
 ```
 #### Gentoo
 ```bash
- sudo emerge --autounmask-write x11-misc/rofi net-libs/zeromq x11-libs/libX11 x11-libs/libXcomposite x11-libs/libXtst x11-libs/libXext x11-libs/libXfixes dev-libs/protobuf dev-libs/spdlog dev-libs/libfmt glfw x11-libs/libGLw  dev-db/sqlite x11-misc/xdotool dev-libs/pthreadpool media-libs/assimp dmenu
+ sudo emerge --autounmask-write x11-misc/rofi net-libs/zeromq x11-libs/libX11 x11-libs/libXcomposite x11-libs/libXtst x11-libs/libXext x11-libs/libXfixes dev-libs/protobuf dev-libs/spdlog dev-libs/libfmt media-libs/glfw x11-libs/libGLw  dev-db/sqlite x11-misc/xdotool dev-libs/pthreadpool media-libs/assimp dmenu
 ```
 > [!NOTE]
 > you may have some issues with use flags and or masked packages. you will have to figure that out on your own system.


### PR DESCRIPTION
There are two packages called glfw so resulted in an ambiguous error:

```
[ Results for search key : glfw ]
*  dev-python/glfw [ Masked ]
      Latest version available: 2.9.0
      Latest version installed: [ Not Installed ]
      Size of files: 482 KiB
      Homepage:      https://github.com/FlorianRhiem/pyGLFW https://pypi.org/project/glfw
      Description:   Python bindings for GLFW
      License:       MIT

*  media-libs/glfw
      Latest version available: 3.4
      Latest version installed: [ Not Installed ]
      Size of files: 915 KiB
      Homepage:      https://www.glfw.org/
      Description:   Portable OpenGL FrameWork
      License:       ZLIB

[ Applications found : 2 ]

!!! The short ebuild name "glfw" is ambiguous. Please specify
!!! one of the above fully-qualified ebuild names instead.
```

I made sure to specify it was from media-libs