### PR TITLE
add updated PKGBUILD to distributions/arch

### DIFF
--- a/distributions/arch/HackMatrix.desktop
+++ b/distributions/arch/HackMatrix.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=HackMatrix
+Comment=A 3D linux desktop environment (which can also be a game engine)
+Exec=/usr/bin/hackmatrix
+Icon=utilities-terminal
+Terminal=false
+Categories=System;Utility;Graphics;
+StartupNotify=true

--- a/distributions/arch/PKGBUILD
+++ b/distributions/arch/PKGBUILD
@@ -1,22 +1,76 @@
-pkgname=hackmatrix
-pkgver=1.0.0
+# NOTE! This package is compiled without a -j flag, since some users might prefer to set it on their own.
+# If you would like to set the -j flag, please edit the PKGBUILD or use MAKEFLAGS e.g: MAKEFLAGS="-j$(nproc)"
+pkgname=hackmatrix-git
 pkgrel=1
-pkgdesc="A 3d openworld desktop engine"
+pkgdesc="HackMatrix is a 3D Linux desktop environment (which can also be a game engine)"
+pkgver=r1117.1.stable.r290.gba01822
 arch=('x86_64')
 url="https://github.com/collinalexbell/HackMatrix"
 license=('MIT')
-depends=('xdotool' 'dmenu' 'xorg-server' 'xorg-xinit' 'xorg-xwininfo' 'xorg-xrandr' 'protobuf' 'base-devel' 'zeromq' 'libx11' 'libxcomposite' 'libxtst' 'libxext' 'libxfixes' 'spdlog' 'fmt' 'glfw-x11' 'mesa' 'assimp' 'sqlite')
-makedepends=('git' 'base-devel')
-source=("git+https://github.com/collinalexbell/HackMatrix.git")
-sha256sums=('SKIP')
+depends=(
+  'wayland'
+  'xorg-server'
+  'xorg-xinit'
+  'libx11'
+  'libxcomposite'
+  'libxtst'
+  'libxext'
+  'libxfixes'
+  'mesa'
+  'glfw-x11'
+  'xdotool'
+  'xorg-xrandr'
+  'xorg-xwininfo'
+  'sqlite'
+  'zeromq'
+  'assimp'
+  'fmt'
+  'spdlog'
+  'wlroots0.19'
+)
+
+makedepends=(
+  'base-devel'
+  'cmake'
+  'git'
+  'wayland-protocols'
+  'protobuf'
+)
+
+pkgver() {
+  cd "$srcdir/HackMatrix"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git describe --long --tags --always | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//')"
+}
+source=(
+  "HackMatrix::git+https://github.com/collinalexbell/HackMatrix.git"
+)
+sha256sums=(
+  'SKIP'
+)
+
+prepare() {
+  cd "$srcdir/HackMatrix"
+  echo "Syncing submodules"
+  git submodule update --init --recursive
+  echo "Applying wlroots patch"
+  patch -p0 < ../../wlroots-fix.patch
+}
 
 build() {
-    cd "HackMatrix"
-    git submodule update --init
-    make
+  cd "$srcdir/HackMatrix"
+  mkdir -pv build
+  cd build
+  cmake ..
+  make
 }
 
 package() {
-    cd "HackMatrix"
-    make DESTDIR="$pkgdir/usr/" install
+  cd "$srcdir/HackMatrix"
+  echo "Installing HackMatrix binaries"
+  install -Dm755 ../../matrix-script "$pkgdir/usr/bin/hackmatrix"
+  install -Dm755 build/matrix "$pkgdir/usr/share/HackMatrix/hackmatrix-binary"
+  install -Dm755 ../../HackMatrix.desktop "$pkgdir/usr/share/applications/HackMatrix.desktop"
+  install -Dm644 config.yaml "$pkgdir/usr/share/HackMatrix/config.yaml"
+  cp -r vox shaders scripts db "$pkgdir/usr/share/HackMatrix/"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/distributions/arch/matrix-script
+++ b/distributions/arch/matrix-script
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -x
+
+BIN="${MATRIX_WLROOTS_BIN:-/usr/share/HackMatrix/hackmatrix-binary}"
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/xdg-runtime-$USER}"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+export XCURSOR_THEME="${XCURSOR_THEME:-Adwaita}"
+export XCURSOR_SIZE="${XCURSOR_SIZE:-24}"
+export XCURSOR_PATH="${XCURSOR_PATH:-/usr/share/icons}"
+
+export WLR_NO_HARDWARE_CURSORS=1
+export MATRIX_WAYLANDAPP_SAMPLE_LOGS="${MATRIX_WAYLANDAPP_SAMPLE_LOGS:-1}"
+export WLR_APP_SAMPLE_LOG=1
+export ENABLE_RENDER_TMP_LOGS=1
+
+BACKEND=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --headless|--drm|--wayland)
+      BACKEND="${1#--}"
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# auto-detect wayland session
+if [[ -z "$BACKEND" && -n "${WAYLAND_DISPLAY:-}" ]]; then
+  BACKEND="wayland"
+fi
+
+if [[ -n "$BACKEND" ]]; then
+  export WLR_BACKENDS="$BACKEND"
+
+  if [[ "$BACKEND" == "drm" ]]; then
+    export LIBSEAT_BACKEND="${LIBSEAT_BACKEND:-logind}"
+
+    if [[ -z "${WLR_DRM_DEVICES:-}" && -e /dev/dri/card0 ]]; then
+      export WLR_DRM_DEVICES="/dev/dri/card0"
+    fi
+
+    export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    mkdir -p "$XDG_RUNTIME_DIR"
+    chmod 700 "$XDG_RUNTIME_DIR"
+  fi
+fi
+
+export CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/HackMatrix"
+if [ ! -d "$CONFIG_DIR" ]; then
+  mkdir -p "$CONFIG_DIR"
+  cp -r /usr/share/HackMatrix/db /usr/share/HackMatrix/vox /usr/share/HackMatrix/scripts/ /usr/share/HackMatrix/shaders /usr/share/HackMatrix/config.yaml "$CONFIG_DIR/"
+fi
+
+cd "$CONFIG_DIR" || {
+  echo "Failed to cd into $CONFIG_DIR"
+  exit 1
+}
+
+exec "$BIN" "$@"

--- a/distributions/arch/wlroots-fix.patch
+++ b/distributions/arch/wlroots-fix.patch
@@ -1,0 +1,22 @@
+--- wlroots/backend/libinput/switch.c	2026-04-27 17:31:58.380560460 +0200
++++ wlroots/backend/libinput/switch.c	2026-04-27 17:16:07.316682031 +0200
+@@ -36,6 +36,8 @@
+ 	case LIBINPUT_SWITCH_TABLET_MODE:
+ 		wlr_event.switch_type = WLR_SWITCH_TYPE_TABLET_MODE;
+ 		break;
++	default:
++		return;
+ 	}
+ 	switch (libinput_event_switch_get_switch_state(sevent)) {
+ 	case LIBINPUT_SWITCH_STATE_OFF:
+--- wlroots/xcursor/xcursor.c	2026-04-27 17:31:58.397099167 +0200
++++ wlroots/xcursor/xcursor.c	2026-04-27 17:16:56.438892523 +0200
+@@ -602,7 +602,7 @@
+ static const char *
+ xcursor_next_path(const char *path)
+ {
+-	char *colon = strchr(path, ':');
++	const char *colon = strchr(path, ':');
+ 
+ 	if (!colon)
+ 		return NULL;

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,8 @@ sudo dnf install wayland-protocols wayland wofi rofi xdotool xorg-x11-utils prot
 I'm currently working on an issue with protobuf compilation errors for Arch. [This PR](https://github.com/collinalexbell/HackMatrix/pull/48) shows how to resolve the issue.
 If you are on Arch and would like to help with a PR that I can get merged into master, try out [this PR](https://github.com/collinalexbell/HackMatrix/pull/55) and let me know in the PR comments if it works for you. It would be much appreciated!
 
+On arch you can also install the PKGBUILD in the directory distributions/arch/
+
 ```bash
 sudo pacman -S --needed wofi wayland-protocols xdotool rofi xorg-server xorg-xinit xorg-xwininfo xorg-xrandr protobuf base-devel zeromq libx11 libxcomposite libxtst libxext libxfixes spdlog fmt glfw-x11 mesa assimp sqlite
 ```


### PR DESCRIPTION
this PR adds an updated PKGBUILD into distributions/arch, replacing the old PKGBUILD.
it also edits the readme.md file to reference the PKGBUILD as an alternative option to building straight from source